### PR TITLE
Enlarge color difference between options in Confirm Alert

### DIFF
--- a/gradle/changelog/confirm_alert_button.yaml
+++ b/gradle/changelog/confirm_alert_button.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Enlarge color difference between options in Confirm Alert ([#47](https://github.com/scm-manager/scm-statistic-plugin/pull/47))

--- a/src/main/js/RebuildStatistics.tsx
+++ b/src/main/js/RebuildStatistics.tsx
@@ -56,11 +56,11 @@ const RebuildStatistics: FC<Props> = ({ statisticsLinks }) => {
         message={t("scm-statistic-plugin.confirmRebuildStatistics.message")}
         buttons={[
           {
-            className: "is-outlined",
             label: t("scm-statistic-plugin.confirmRebuildStatistics.submit"),
             onClick: () => rebuildStatistic()
           },
           {
+            className: "is-info",
             label: t("scm-statistic-plugin.confirmRebuildStatistics.cancel"),
             onClick: () => null
           }


### PR DESCRIPTION
## Proposed changes

Enlarge color difference between options in Confirm Alert

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
